### PR TITLE
Support Laravel 5.4+, Add Trait for convenience, Update Readme.md

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,5 @@
 
             }
         }
-    },
-    "config": {
-        "allow-plugins": {
-            "kylekatarnls/update-helper": true
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,13 @@
             }
         },
     "require": {
-        
+        "php": ">=7.0.0",
+        "illuminate/http": ">=v5.4.0",
+        "illuminate/view": ">=v5.4.0",
+        "ext-json": "*"
     },
     "require-dev": {
-        
+
     },
     "minimum-stability": "dev",
     "extra": {
@@ -29,6 +32,11 @@
             "aliases": {
 
             }
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "kylekatarnls/update-helper": true
         }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -24,59 +24,26 @@ Install the module with:
 composer require manyapp/duskapiconf --dev
 ```
 
-Then, you will have to modify your `DustTestCase.php` to add three methods. Alternatively, you can add the following methods to the Trait of your choice and use the Trait in your Dusk tests.
-
+For Laravel versions prior to 5.5 register the service. 
 ```
-/**
-* Set live config option
-*
-* @param string $key 
-* @param mixed $value
-* @return void
-*/
-public function setConfig($key, $value)
+if ($this->app->environment() !== 'production') {            
+    $this->app->register(Manyapp\DuskApiConf\Controllers\DuskApiConfServiceProvider::class);
+} 
+```
+
+Then, you will have to modify your Dusk Tests to add the Trait.
+
+Example
+```
+<?php
+
+namespace Tests\Browser;
+
+use Manyapp\DuskApiConf\Traits\DuskConfigApi;
+
+class YourDuskTest extends DuskTestCase
 {
-    $encoded = base64_encode(json_encode($value));
-    $query = "?key=".$key.'&value='.$encoded;
-    $this->browse(function($browser) use ($query) {
-        $data = $browser->visit('/duskapiconf/set'.$query)->element('.content')->getAttribute('innerHTML');
-        $data = trim($data);
-        if ($data !== 'ok') {
-            $this->assertTrue(false);
-        }
-    });
-}
-
-
-/**
-* Get a current configuration item
-*
-* @param string $key
-* @return mixed
-*/
-public function getConfig($key)
-{
-    $query = "?key=".$key;
-    $result = null;
-    $this->browse(function($browser) use ($query, &$result) {
-        $data = $browser->visit('/duskapiconf/get'.$query)->element('.content')->getAttribute('innerHTML');
-        $result = json_decode(base64_decode($data), true);
-    });
-    return $result;
-}
-
-/**
-* Reset the configuration to its initial status
-*
-* @return void
-*/
-public function resetConfig()
-{
-    $this->browse(function($browser) {
-        $browser->visit('/duskapiconf/reset');
-    });
-}
-
+    use DuskConfigApi;
 ```
 
 ## Usage

--- a/src/Controllers/DuskApiConfController.php
+++ b/src/Controllers/DuskApiConfController.php
@@ -13,7 +13,7 @@ class DuskApiConfController
     public function get()
     {
         $request = request();
-        if (! $request->filled('key')) {
+        if (! $request->get('key',false)) {
             return view('duskapiconf::data', ['value' => 'error_not_all_parameters']);
         }
         $value = config($request->input('key'));
@@ -29,7 +29,7 @@ class DuskApiConfController
     {
         $request = request();
 
-        if ( (! $request->filled('key')) || (! $request->filled('value')) ) {
+        if ((!$request->get('key', false)) || (!$request->get('value', false))) {
             return view('duskapiconf::data', ['value' => 'error_not_all_parameters']);
         } else {
 

--- a/src/Traits/DuskConfigApi.php
+++ b/src/Traits/DuskConfigApi.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Manyapp\DuskApiConf\Traits;
+
+/**
+ * https://many.app/changing-laravel-configuration-during-dusk-tests/
+ * https://github.com/manyapp/duskapiconf
+ */
+trait DuskConfigApi
+{
+    /**
+     * Set live config option
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function setConfig($key, $value)
+    {
+        $encoded = base64_encode(json_encode($value));
+        $query = "?key=".$key.'&value='.$encoded;
+        $this->browse(function ($browser) use ($query) {
+            $data = $browser->visit('/duskapiconf/set'.$query)->element('.content')->getAttribute('innerHTML');
+            $data = trim($data);
+            if ($data !== 'ok') {
+                $this->assertTrue(false);
+            }
+        });
+    }
+
+
+    /**
+     * Get a current configuration item
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function getConfig($key)
+    {
+        $query = "?key=".$key;
+        $result = null;
+        $this->browse(function ($browser) use ($query, &$result) {
+            $data = $browser->visit('/duskapiconf/get'.$query)->element('.content')->getAttribute('innerHTML');
+            $result = json_decode(base64_decode($data), true);
+        });
+
+        return $result;
+    }
+
+    /**
+     * Reset the configuration to its initial status
+     *
+     * @return void
+     */
+    public function resetConfig()
+    {
+        $this->browse(function ($browser) {
+            $browser->visit('/duskapiconf/reset');
+        });
+    }
+
+}


### PR DESCRIPTION
- allow earlier versions of laravel - replace request->filled with request->get()
- add Trait to make easier/consistent to use.
- update readme.md